### PR TITLE
Switch buildspec.yml to hybrid tox/old-style deploy.sh.

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,11 +1,11 @@
 version: 0.2
 phases:
-  install:
-    commands:
-      - pip install tox
-  build:
-    commands:
-      - tox -e build
-  post_build:
-    commands:
-      - tox -e deploy
+    install:
+       commands:
+         - pip install tox
+    build:
+       commands:
+         - tox -e build
+    post_build:
+      commands:
+        ./deploy.sh


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Switch `buildspec.yml` to hybrid tox/old-style `deploy.sh`. This is based on the `buildspec.yml` from the previous build setup with some changes to hook in to `tox` for the new Sphinx build.

See also https://github.com/aws-samples/reinvent-sid345-workshop-sample/blob/e2db11755b1a843c0128c865fc968267ea49c529/buildspec.yml

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
